### PR TITLE
Fix asdfghjkl dependency version

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   host:
     - pip
-    - python ${{ python_min }}
+    - python >=${{ python_min }}
     - setuptools
     - setuptools-scm
   run:
@@ -42,7 +42,7 @@ tests:
         - laplace
         - laplace.curvature
       requires:
-        - python ${{ python_min }}
+        - python >=${{ python_min }}
 
 about:
   summary: laplace - Laplace approximations for deep learning

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -41,6 +41,7 @@ tests:
       imports:
         - laplace
         - laplace.curvature
+      python_version: ${{ python_min }}.*
 
 about:
   summary: laplace - Laplace approximations for deep learning

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,31 +1,31 @@
-context:
-  name: laplace-torch
-  version: 0.2.1
+{% set name = "laplace-torch" %}
+{% set version = "0.2.1" %}
+{% set python_min = "3.8" %}
 
 package:
   name: ${{ name|lower }}
   version: ${{ version }}
 
 source:
-  url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/${{ name | replace('-', '_') }}-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name | replace('-', '_') }}-${{ version }}.tar.gz
   sha256: 641823a6d3e1dcb8297202b896ae2969334bf96df9a4a6f8cf688896d67d96f2
 
 build:
   number: 1
   noarch: python
-  script: python -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python ${{ python_min }}
     - setuptools
     - setuptools-scm
   run:
     - asdfghjkl
     - backpack-for-pytorch
     - curvlinops-for-pytorch
-    - python >=3.8
+    - python >=${{ python_min }}
     - pytorch
     - torchvision
     - torchmetrics
@@ -36,10 +36,11 @@ requirements:
     - torchaudio
 
 tests:
-  - python:
-      imports:
-        - laplace
-        - laplace.curvature
+  imports:
+    - laplace
+    - laplace.curvature
+  requires:
+    - python ${{ python_min }}
 
 about:
   summary: laplace - Laplace approximations for deep learning

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   host:
     - pip
-    - python >=${{ python_min }}
+    - python ${{ python_min }}
     - setuptools
     - setuptools-scm
   run:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: laplace-torch
   version: 0.2.1
-  python_min: "3.8"
+  python_min: "3.9"
 
 package:
   name: ${{ name|lower }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -32,7 +32,7 @@ requirements:
     - numpy
     - tqdm
     - opt_einsum
-    - asdfghjkl
+    - asdfghjkl ==0.1a4
     - torchaudio
 
 tests:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   host:
     - pip
-    - python ${{ python_min }}
+    - python ${{ python_min }}.*
     - setuptools
     - setuptools-scm
   run:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 641823a6d3e1dcb8297202b896ae2969334bf96df9a4a6f8cf688896d67d96f2
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install . -vv
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -41,8 +41,6 @@ tests:
       imports:
         - laplace
         - laplace.curvature
-      requires:
-        - python >=${{ python_min }}
 
 about:
   summary: laplace - Laplace approximations for deep learning

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,7 @@
-{% set name = "laplace-torch" %}
-{% set version = "0.2.1" %}
-{% set python_min = "3.8" %}
+context:
+  name: laplace-torch
+  version: 0.2.1
+  python_min: "3.8"
 
 package:
   name: ${{ name|lower }}
@@ -36,11 +37,12 @@ requirements:
     - torchaudio
 
 tests:
-  imports:
-    - laplace
-    - laplace.curvature
-  requires:
-    - python ${{ python_min }}
+  - python:
+      imports:
+        - laplace
+        - laplace.curvature
+      requires:
+        - python ${{ python_min }}
 
 about:
   summary: laplace - Laplace approximations for deep learning

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: python -m pip install . -vv
 
 requirements:
   host:


### PR DESCRIPTION
According to the source on PyPI, `asdfghjkl == 0.1a4` is required. Without this, the version may vary, and things like `pip check` will break for all packages that depend on laplace-torch. If we don't want this version pinning, we should try to convince the upstream authors to remove it from the official source.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.